### PR TITLE
- remove keys with null values in each material json file

### DIFF
--- a/materials/generic_filter_zm_turned.json
+++ b/materials/generic_filter_zm_turned.json
@@ -34,9 +34,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -85,6 +83,5 @@
 		"columns": 1,
 		"rows": 1
 	},
-	"textures": [],
-	"thermalMaterial": null
+	"textures": []
 }

--- a/materials/hud_indicator_blundersplat.json
+++ b/materials/hud_indicator_blundersplat.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_highrise_dpad.json
+++ b/materials/hud_zm_highrise_dpad.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_highrise_dpad_bar.json
+++ b/materials/hud_zm_highrise_dpad_bar.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_nuked_dpad.json
+++ b/materials/hud_zm_nuked_dpad.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_nuked_dpad_bar.json
+++ b/materials/hud_zm_nuked_dpad_bar.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_0.json
+++ b/materials/hud_zm_num_highrise_0.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_1.json
+++ b/materials/hud_zm_num_highrise_1.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_2.json
+++ b/materials/hud_zm_num_highrise_2.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_3.json
+++ b/materials/hud_zm_num_highrise_3.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_4.json
+++ b/materials/hud_zm_num_highrise_4.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_5.json
+++ b/materials/hud_zm_num_highrise_5.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_6.json
+++ b/materials/hud_zm_num_highrise_6.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_7.json
+++ b/materials/hud_zm_num_highrise_7.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_8.json
+++ b/materials/hud_zm_num_highrise_8.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_9.json
+++ b/materials/hud_zm_num_highrise_9.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_line.json
+++ b/materials/hud_zm_num_highrise_line.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_highrise_slash.json
+++ b/materials/hud_zm_num_highrise_slash.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_0.json
+++ b/materials/hud_zm_num_transit_0.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_1.json
+++ b/materials/hud_zm_num_transit_1.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_2.json
+++ b/materials/hud_zm_num_transit_2.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_3.json
+++ b/materials/hud_zm_num_transit_3.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_4.json
+++ b/materials/hud_zm_num_transit_4.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_5.json
+++ b/materials/hud_zm_num_transit_5.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_6.json
+++ b/materials/hud_zm_num_transit_6.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_7.json
+++ b/materials/hud_zm_num_transit_7.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_8.json
+++ b/materials/hud_zm_num_transit_8.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_9.json
+++ b/materials/hud_zm_num_transit_9.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_line.json
+++ b/materials/hud_zm_num_transit_line.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_num_transit_slash.json
+++ b/materials/hud_zm_num_transit_slash.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_transit_dpad.json
+++ b/materials/hud_zm_transit_dpad.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/hud_zm_transit_dpad_bar.json
+++ b/materials/hud_zm_transit_dpad_bar.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon.json
+++ b/materials/mc/mtl_weapon_camo_dragon.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_1.json
+++ b/materials/mc/mtl_weapon_camo_dragon_1.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_2.json
+++ b/materials/mc/mtl_weapon_camo_dragon_2.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_3.json
+++ b/materials/mc/mtl_weapon_camo_dragon_3.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_attach.json
+++ b/materials/mc/mtl_weapon_camo_dragon_attach.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_attach_1.json
+++ b/materials/mc/mtl_weapon_camo_dragon_attach_1.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/mc/mtl_weapon_camo_dragon_attach_2.json
+++ b/materials/mc/mtl_weapon_camo_dragon_attach_2.json
@@ -128,7 +128,6 @@
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
 			"srcBlendRgb": "one",
-			"stencilBack": null,
 			"stencilFront": {
 				"fail": "keep",
 				"func": "equal",
@@ -150,9 +149,7 @@
 			"polygonOffset": "offsetShadowmap",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -168,9 +165,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -186,9 +181,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -204,9 +197,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -360,6 +351,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_blundergat.json
+++ b/materials/menu_zm_weapons_blundergat.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_blundersplat.json
+++ b/materials/menu_zm_weapons_blundersplat.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_item_head.json
+++ b/materials/menu_zm_weapons_item_head.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_item_meat.json
+++ b/materials/menu_zm_weapons_item_meat.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_knife_alcatraz.json
+++ b/materials/menu_zm_weapons_knife_alcatraz.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch.json
+++ b/materials/menu_zm_weapons_one_inch_punch.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch_air.json
+++ b/materials/menu_zm_weapons_one_inch_punch_air.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch_fire.json
+++ b/materials/menu_zm_weapons_one_inch_punch_fire.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch_ice.json
+++ b/materials/menu_zm_weapons_one_inch_punch_ice.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch_lightning.json
+++ b/materials/menu_zm_weapons_one_inch_punch_lightning.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_one_inch_punch_upgraded.json
+++ b/materials/menu_zm_weapons_one_inch_punch_upgraded.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_ray_gun.json
+++ b/materials/menu_zm_weapons_ray_gun.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_raygun_mark2.json
+++ b/materials/menu_zm_weapons_raygun_mark2.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_spoon_alcatraz.json
+++ b/materials/menu_zm_weapons_spoon_alcatraz.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_spork_alcatraz.json
+++ b/materials/menu_zm_weapons_spork_alcatraz.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/menu_zm_weapons_syrette.json
+++ b/materials/menu_zm_weapons_syrette.json
@@ -24,9 +24,7 @@
 			"polygonOffset": "offset0",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		}
 	],
 	"stateBitsEntry": [
@@ -89,6 +87,5 @@
 			},
 			"semantic": "2D"
 		}
-	],
-	"thermalMaterial": null
+	]
 }

--- a/materials/wpc/mtl_zb_signs.json
+++ b/materials/wpc/mtl_zb_signs.json
@@ -37,9 +37,7 @@
 			"polygonOffset": "offset1",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "srcalpha",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "srcalpha"
 		},
 		{
 			"alphaTest": "gt0",
@@ -55,9 +53,7 @@
 			"polygonOffset": "offset1",
 			"polymodeLine": false,
 			"srcBlendAlpha": "invdestalpha",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -73,9 +69,7 @@
 			"polygonOffset": "offset2",
 			"polymodeLine": true,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		},
 		{
 			"alphaTest": "disabled",
@@ -91,9 +85,7 @@
 			"polygonOffset": "offset1",
 			"polymodeLine": false,
 			"srcBlendAlpha": "one",
-			"srcBlendRgb": "one",
-			"stencilBack": null,
-			"stencilFront": null
+			"srcBlendRgb": "one"
 		}
 	],
 	"stateBitsEntry": [
@@ -182,6 +174,5 @@
 			},
 			"semantic": "colorMap"
 		}
-	],
-	"thermalMaterial": null
+	]
 }


### PR DESCRIPTION


This works around issues with OpenAssetTools linker.exe silently failing when parsing these files