### PR TITLE
Restructure build process to work with OAT >=v0.20.0

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -9,8 +9,8 @@ mode 150, 30
 --load "%OAT_GAME%\zone\all\zm_prison.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\dependencies" dependencies\camo_zmb_dlc2_materials
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\dependencies" camo_zmb_dlc2_materials
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -19,8 +19,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\zm_tomb.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\dependencies" dependencies\camo_zmb_dlc4_materials
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\dependencies" camo_zmb_dlc4_materials
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -32,8 +32,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\common_mp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\dependencies" dependencies\camo_materials
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\dependencies" camo_materials
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -42,8 +42,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\weapons!metalstorm_mms_sp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\weapons!metalstorm_mms_sp
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" weapons!metalstorm_mms_sp
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -52,8 +52,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\weapons!exptitus6_sp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\weapons!exptitus6_sp
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" weapons!exptitus6_sp
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -61,8 +61,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\code_post_gfx.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\code_post_gfx
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" code_post_gfx
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -71,8 +71,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\frontend.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\frontend
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" frontend
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -80,8 +80,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\so_cmp_afghanistan.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\afghanistan
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" afghanistan
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -92,8 +92,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\common_mp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\common_mp
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" common_mp
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -101,8 +101,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\code_post_gfx_mp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\code_post_gfx_mp
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" code_post_gfx_mp
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -110,8 +110,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\english\en_code_post_gfx_mp.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\en_code_post_gfx_mp
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" en_code_post_gfx_mp
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -121,8 +121,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\common_zm.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\common_zm
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" common_zm
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -131,8 +131,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\ui_zm.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\ui_zm
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" ui_zm
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -143,8 +143,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\so_zsurvival_zm_transit.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_transit
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_transit
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -154,8 +154,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\zm_nuked.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_nuked
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_nuked
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -165,8 +165,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\zm_highrise.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_highrise
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_highrise
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -177,8 +177,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\so_zencounter_zm_prison.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_prison
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_prison
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -189,8 +189,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\so_zencounter_zm_buried.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_buried
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_buried
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -200,8 +200,8 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%OAT_GAME%\zone\all\zm_tomb.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
---output-folder "%cd%\zone_source\includes" includes\zm_tomb
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
+--output-folder "%cd%\zone_source\includes" zm_tomb
 
 if %ERRORLEVEL% NEQ 0 pause
 
@@ -225,7 +225,7 @@ if %ERRORLEVEL% NEQ 0 pause
 --load "%cd%\zone_source\includes\zm_tomb.ff" ^
 --base-folder "%OAT_BASE%" ^
 --asset-search-path "%cd%" ^
---source-search-path "%cd%\zone_source" ^
+--source-search-path "%cd%\zone_source;%cd%\zone_source\dependencies;%cd%\zone_source\includes" ^
 --output-folder "%cd%" mod
 
 if %ERRORLEVEL% NEQ 0 pause

--- a/zone_source/dependencies/camo_materials.zone
+++ b/zone_source/dependencies/camo_materials.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,camo_materials
 
 include,dependencies/camo_zmb_dlc4_materials
 include,dependencies/camo_zmb_dlc2_materials

--- a/zone_source/dependencies/camo_zmb_dlc2_materials.zone
+++ b/zone_source/dependencies/camo_zmb_dlc2_materials.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,camo_zmb_dlc2_materials
 
 material,mc/mtl_weapon_camo_zmb_dlc2
 material,mc/mtl_weapon_camo_zmb_dlc2_1

--- a/zone_source/dependencies/camo_zmb_dlc4_materials.zone
+++ b/zone_source/dependencies/camo_zmb_dlc4_materials.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,camo_zmb_dlc4_materials
 
 material,mc/mtl_weapon_camo_3layer
 material,mc/mtl_weapon_camo_3layer_1

--- a/zone_source/includes/afghanistan.zone
+++ b/zone_source/includes/afghanistan.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,afghanistan
 
 xanim,viewmodel_mine_tc6_idle
 xanim,viewmodel_mine_tc6_fire

--- a/zone_source/includes/code_post_gfx.zone
+++ b/zone_source/includes/code_post_gfx.zone
@@ -1,5 +1,3 @@
 >game,T6
->type,fastfile
->name,code_post_gfx
 
 material,hud_monsoon_titus_arrow

--- a/zone_source/includes/code_post_gfx_mp.zone
+++ b/zone_source/includes/code_post_gfx_mp.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,code_post_gfx_mp
 
 material,menu_mp_weapons_ballistic_knife
 material,menu_mp_weapons_as50

--- a/zone_source/includes/common_mp.zone
+++ b/zone_source/includes/common_mp.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,common_mp
 
 xmodel,t6_wpn_knife_base_view
 xmodel,t6_wpn_knife_base_world

--- a/zone_source/includes/common_zm.zone
+++ b/zone_source/includes/common_zm.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,common_zm
 
 material,generic_filter_zm_turned
 

--- a/zone_source/includes/en_code_post_gfx_mp.zone
+++ b/zone_source/includes/en_code_post_gfx_mp.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,en_code_post_gfx_mp
 
 material,white_waypoint_target
 material,white_waypoint_capture

--- a/zone_source/includes/frontend.zone
+++ b/zone_source/includes/frontend.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,frontend
 
 material,menu_mp_weapons_minigun_future
 material,menu_mp_weapons_m32gl

--- a/zone_source/includes/ui_zm.zone
+++ b/zone_source/includes/ui_zm.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,ui_zm
 
 material,menu_zm_transit_zclassic_transit
 material,menu_zm_highrise_zclassic_rooftop

--- a/zone_source/includes/weapons!exptitus6_sp.zone
+++ b/zone_source/includes/weapons!exptitus6_sp.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,weapons!exptitus6_sp
 
 material,mc/mtl_t6_attach_optic_titus_reticle
 material,mc/mtl_t6_wpn_lmg_type95_drum_thermal

--- a/zone_source/includes/weapons!metalstorm_mms_sp.zone
+++ b/zone_source/includes/weapons!metalstorm_mms_sp.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,weapons!metalstorm_mms_sp
 
 material,mc/mtl_t6_wpn_special_storm_thermal
 material,mc/mtl_t6_wpn_special_storm

--- a/zone_source/includes/zm_buried.zone
+++ b/zone_source/includes/zm_buried.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_buried
 
 script,aitype/zm_buried_ghost_female.gsc
 xanim,ai_zombie_ghost_idle

--- a/zone_source/includes/zm_highrise.zone
+++ b/zone_source/includes/zm_highrise.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_highrise
 
 weapon,zombie_perk_bottle_whoswho
 material,specialty_chugabud_zombies

--- a/zone_source/includes/zm_nuked.zone
+++ b/zone_source/includes/zm_nuked.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_nuked
 
 weapon,hk416_zm
 weapon,hk416_upgraded_zm

--- a/zone_source/includes/zm_prison.zone
+++ b/zone_source/includes/zm_prison.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_prison
 
 techniqueset,mc_lit_sm_r0c0n0x0_q361191u
 image,jun_art_plastic_tarp_n

--- a/zone_source/includes/zm_tomb.zone
+++ b/zone_source/includes/zm_tomb.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_tomb
 
 weapon,zombie_perk_bottle_nuke
 material,specialty_divetonuke_zombies

--- a/zone_source/includes/zm_transit.zone
+++ b/zone_source/includes/zm_transit.zone
@@ -1,6 +1,4 @@
 >game,T6
->type,fastfile
->name,zm_transit
 
 weapon,zombie_perk_bottle_tombstone
 material,specialty_tombstone_zombies

--- a/zone_source/mod.zone
+++ b/zone_source/mod.zone
@@ -1,5 +1,4 @@
 >game,T6
->type,fastfile
 >name,mod
 
 >level.ipak_read,patch_mp


### PR DESCRIPTION
The current build process has a few things that I didn't expect people to be making use of so they were broken in v0.20.0 unfortunately.

First things is making use of making a project name have a backslash.
OAT does try to extract a "project-name" and a "target-name" from your build command.
The format is like `projectName/targetName`.

The project is then made use of when building up the output path, source search path, asset paths, etc.
So by default it would output to `zone_out/projectName/targetName.ff`.
If there is no targetName set (no forward slash) then the targetName would be set to the projectName.

Using the backslash to do directory traversal does work when finding the zone file here but the output will be in `out/dependencies/common_mp/dependencies/common_mp.ff` now for example which is different from before.

Being able to do directory traversal like this was honestly unintended and is not portable cross platform either since backslash is not a directory separator on linux and forward slash is interpreted differently.
So i'd avoid that 😅 

-----

Secondly with the new include system it changed so the last `>name,...` metadata does set the name now.
When including another zone definition, their metadata is now also taken into account.
This makes the dependencies and includes use wrong names unfortunately when they include something else.

Since the default behaviour is setting the name to the targetName, it can just be taken away here as long as the build specifies is no longer doing the directory traversal from above.

------

All in all this is just a suggestion on how the build process could work in a way that i more expected people to be using OAT when writing the code, so this is working on both versions before and after 0.20.0.

Feel free to do whatever with this though, close it, discard it, change it, take it, whatever you want :)
Just doing this to give you an idea of what I was thinking of.